### PR TITLE
Feature: Meta tags voor SEO optimalisatie

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,11 @@
       <meta name="robots" content="index, follow">
     {{ end }}
 
+    {{ block "meta-tags"}}
+      <meta name="description" content="{{ $.Summary | default "Zit je ergens vast bij wiskunde of fysica? Met Hoe Zit Het? heb je de leerstof razendsnel onder de knie. Neem maar eens een kijkje naar onze lessen. Ze zijn kort, krachtig, vol illustraties en bovenal helemaal gratis!"}}"/> 
+      <meta name="keywords" content="{{ $.Keywords | default "wiskunde oefeningen, wiskunde, fysica oefeningen, fysica, lessen, afgeleiden, integralen, krachten" }}"/> 
+    {{ end }}
+
     {{ block "json_ld" . }}
       {{ partial "head/seo/organisation" . }}
       {{ partial "head/seo/breadcrumb" . }}

--- a/layouts/lessen/single.html
+++ b/layouts/lessen/single.html
@@ -1,20 +1,15 @@
 {{ define "header" }}
-  <header>
-    {{ partial "header/site-navigation.html" . }}
-  </header>
-{{ end }}
-
-{{ define "mathjax" }} {{ partial "head/mathjax" . }} {{ end }}
-{{ define "bokeh" }} {{ partial "head/bokeh" . }} {{ end }}
-{{ define "fancybox" }} {{ partial "head/fancybox" . }} {{ end }}
-
-{{ define "json_ld" }}
-  {{ partial "head/seo/organisation" . }}
-  {{ partial "head/seo/breadcrumb" . }}
-  {{ partial "head/seo/article" . }}
-{{ end }}
-
-{{ define "main" }}
+<header>
+  {{ partial "header/site-navigation.html" . }} {{ block "meta-tags"}}
+  <meta name="description" content="{{ $.Params.description | $.Summary }}" />
+  <meta name="keywords" content="{{ $.Params.keywords | $.Keywords }}" />
+  {{ end }}
+</header>
+{{ end }} {{ define "mathjax" }} {{ partial "head/mathjax" . }} {{ end }} {{
+define "bokeh" }} {{ partial "head/bokeh" . }} {{ end }} {{ define "fancybox" }}
+{{ partial "head/fancybox" . }} {{ end }} {{ define "json_ld" }} {{ partial
+"head/seo/organisation" . }} {{ partial "head/seo/breadcrumb" . }} {{ partial
+"head/seo/article" . }} {{ end }} {{ define "main" }}
 <article class="mw8 center ph3">
   <h1 class="f1" style="color: {{ $.Parent.Params.section_color }};">
     {{ .Title }}
@@ -28,12 +23,9 @@
     </div>
     <article class="center cf w-two-thirds-l">
       <section class="nested-copy-line-height lh-copy nested-links">
-        {{ .Content }}
-        {{ partial "main/lessen_icon_links" . }}
-        {{ partial "main/feedback" . }}
-        {{ partial "main/comments" . }}
-        {{ partial "main/tags.html" . }}
-        {{ partial "main/to-top.html" . }}
+        {{ .Content }} {{ partial "main/lessen_icon_links" . }} {{ partial
+        "main/feedback" . }} {{ partial "main/comments" . }} {{ partial
+        "main/tags.html" . }} {{ partial "main/to-top.html" . }}
       </section>
     </article>
   </div>


### PR DESCRIPTION
Eerste poging tot het toevoegen van meta tags aan de template van een html pagina. In een les kunnen nu in de 'front matter' de volgende params gebruikt worden: 'description': korte beschrijving van de inhoud van de les, kan best keywords bevatten. (fallback = summary), 'keywords': Kernwoorden die in de les terugkomen (fallback is .Keywords page var maar ik ben niet zeker of die ingevuld is, dus er staat ook een redelijk generieke default versie in baseof.html